### PR TITLE
Make the /@types endpoint publicly available

### DIFF
--- a/backend/src/ploneorg/src/ploneorg/__init__.py
+++ b/backend/src/ploneorg/src/ploneorg/__init__.py
@@ -7,3 +7,6 @@ import logging
 _ = MessageFactory("ploneorg")
 
 logger = logging.getLogger("ploneorg")
+
+
+from . import patches  # noqa

--- a/backend/src/ploneorg/src/ploneorg/patches.py
+++ b/backend/src/ploneorg/src/ploneorg/patches.py
@@ -1,0 +1,15 @@
+# We need to bypass the check for logged-in users in the /@types endpoint
+# because it is used for rendering the default view.
+# This is not a security problem, because the schemas are already
+# public in the plone.org repository.
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+def bypass_security_check(context):
+    pass
+
+logger.info("Patching plone.restapi.services.types.get.check_security")
+from plone.restapi.services.types import get
+get.check_security = bypass_security_check

--- a/backend/src/ploneorg/src/ploneorg/patches.py
+++ b/backend/src/ploneorg/src/ploneorg/patches.py
@@ -3,6 +3,8 @@
 # This is not a security problem, because the schemas are already
 # public in the plone.org repository.
 
+from plone.restapi.services.types import get
+
 import logging
 
 
@@ -14,7 +16,4 @@ def bypass_security_check(context):
 
 
 logger.info("Patching plone.restapi.services.types.get.check_security")
-from plone.restapi.services.types import get
-
-
 get.check_security = bypass_security_check

--- a/backend/src/ploneorg/src/ploneorg/patches.py
+++ b/backend/src/ploneorg/src/ploneorg/patches.py
@@ -5,11 +5,16 @@
 
 import logging
 
+
 logger = logging.getLogger(__name__)
+
 
 def bypass_security_check(context):
     pass
 
+
 logger.info("Patching plone.restapi.services.types.get.check_security")
 from plone.restapi.services.types import get
+
+
 get.check_security = bypass_security_check

--- a/backend/src/ploneorg/tests/test_types_service.py
+++ b/backend/src/ploneorg/tests/test_types_service.py
@@ -1,0 +1,22 @@
+"""Tests for /@types service patch."""
+from plone.restapi.testing import RelativeSession
+from ploneorg.testing import PLONEORG_FUNCTIONAL_TESTING
+
+import unittest
+
+
+class TestTypesService(unittest.TestCase):
+    """Test /@types API service."""
+
+    layer = PLONEORG_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        """Custom shared utility setup for tests."""
+        self.portal = self.layer["portal"]
+        self.portal_url = self.portal.absolute_url()
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({"Accept": "application/json"})
+
+    def test_anonymous_user_can_view_types_service(self):
+        response = self.api_session.get("/@types")
+        self.assertEqual(200, response.status_code)


### PR DESCRIPTION
See https://github.com/plone/plone.org/issues/55#issuecomment-1343037419 for an explanation.

In the case of plone.org I don't think there is any security problem, because it's only revealing schema information that is already public in this repository.