### PR TITLE
This fixes the size of the images in icons and text block

### DIFF
--- a/frontend/theme/extras/site/components/blocks/icons_and_text.less
+++ b/frontend/theme/extras/site/components/blocks/icons_and_text.less
@@ -118,6 +118,18 @@
               min-height: 8rem;
               max-height: 8rem;
             }
+
+            img[src*='png'],
+            img[src*='jpg'],
+            img[src*='jpeg'],
+            img[src*='gif'] {
+              width: 100%;
+              min-height: unset;
+              max-height: unset;
+              aspect-ratio: var(--grid-images-aspect-ratio, 1.77777778);
+              object-fit: cover;
+              object-position: var(--grid-images-object-position, top left);
+            }
           }
         }
 


### PR DESCRIPTION
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/486927/206863204-a97cfac8-5b73-4ae8-a470-96fe2b84e44e.png">

Since this block seems that it's designed to work with svgs (icons and text block), I've restricted the CSS to have src attributes to contain image extensions. So the image uploaded should have the image extension in the filename.