### PR TITLE
Add hover effect to teasers (#26)

### DIFF
--- a/frontend/theme/extras/custom.overrides
+++ b/frontend/theme/extras/custom.overrides
@@ -45,6 +45,7 @@
 @import 'site/components/blocks/html.less';
 @import 'site/components/blocks/page_metadata.less';
 @import 'site/components/blocks/page_tag.less';
+@import 'site/components/blocks/teaser.less';
 
 @import 'site/components/blocks/icons_and_numbers.less';
 @import 'site/components/blocks/icons_and_text.less';

--- a/frontend/theme/extras/site/components/blocks/teaser.less
+++ b/frontend/theme/extras/site/components/blocks/teaser.less
@@ -1,0 +1,14 @@
+.block.teaser .grid-image-wrapper,
+.block.teaser .grid-teaser-item {
+  overflow: hidden; /* [1.2] Hide the overflowing of child elements */
+
+  img {
+    // [2] Transition property for smooth transformation of images
+    transition: transform 0.5s ease;
+  }
+
+  &:hover img {
+    // [3] Finally, transforming the image when container gets hovered
+    transform: scale(1.05);
+  }
+}


### PR DESCRIPTION
Fixes: #26 This only adds the effect to teasers, we could make them work in other blocks images.

Let me know where do you like to have it.

https://user-images.githubusercontent.com/486927/206863546-bd424ba4-7997-4337-a39b-5ce974cc1a24.mov


