### PR TITLE
fix: avoid hero block image to distort respecting ratio

### DIFF
--- a/frontend/theme/extras/site/components/blocks/hero.less
+++ b/frontend/theme/extras/site/components/blocks/hero.less
@@ -8,13 +8,10 @@
       flex: 0 1 50%;
 
       img {
-        position: absolute;
-        left: 50%;
         min-width: 100%;
-        max-width: unset;
-        height: 100%;
-        max-height: unset;
-        transform: translateX(-50%);
+        min-height: 100%;
+        object-fit: cover;
+        object-position: center;
       }
     }
 


### PR DESCRIPTION
See Kim's photo in https://plone.org/services/training