### PR TITLE
Change hero block title from h1 to h2

### DIFF
--- a/frontend/src/customizations/volto/components/manage/Blocks/HeroImageLeft/View.jsx
+++ b/frontend/src/customizations/volto/components/manage/Blocks/HeroImageLeft/View.jsx
@@ -33,7 +33,7 @@ const View = ({ data }) => (
       )}
       <div className="hero-body">
         <div className="hero-text">
-          {data.title && <h1>{data.title}</h1>}
+          {data.title && <h2>{data.title}</h2>}
           <p>
             {redraft(
               data.description,


### PR DESCRIPTION
Solution for [https://github.com/plone/plone.org/issues/79](https://github.com/plone/plone.org/issues/79).  Line height automatically adjusts from 2.5 (h1) to 1.7 (h2).