### PR TITLE
Use longer lived read only token to deploy

### DIFF
--- a/.github/workflows/deploy-tag-release-live.yml
+++ b/.github/workflows/deploy-tag-release-live.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           registry: "ghcr.io"
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.DEPLOY_GHCR_READ_TOKEN }}
           remote_host: ${{ vars.DEPLOY_HOST }}
           remote_port: ${{ vars.DEPLOY_PORT }}
           remote_user: ${{ vars.DEPLOY_USER }}

--- a/.github/workflows/frontend-testing.yml
+++ b/.github/workflows/frontend-testing.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           registry: "ghcr.io"
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.DEPLOY_GHCR_READ_TOKEN }}
           remote_host: ${{ vars.DEPLOY_HOST }}
           remote_port: ${{ vars.DEPLOY_PORT }}
           remote_user: ${{ vars.DEPLOY_USER }}

--- a/.github/workflows/redeploy-testing.yaml
+++ b/.github/workflows/redeploy-testing.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           registry: "ghcr.io"
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.DEPLOY_GHCR_READ_TOKEN }}
           remote_host: ${{ vars.DEPLOY_HOST }}
           remote_port: ${{ vars.DEPLOY_PORT }}
           remote_user: ${{ vars.DEPLOY_USER }}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,7 +8,7 @@ Below is a list of commands you will probably find useful.
 
 ### `yarn start`
 
-Runs the project in development mode.
+Run the project in development mode.
 You can view your application at `http://localhost:3000`
 
 The page will reload if you make edits.


### PR DESCRIPTION
So Docker Swarm can redownload any released iimage when moving container workload to a new worker.
Noop change in frontend dir to test frontend testing relesae.