### PR TITLE
Add Plone Releases to the site footer.

### DIFF
--- a/frontend/src/customizations/volto/components/theme/Footer/Footer.jsx
+++ b/frontend/src/customizations/volto/components/theme/Footer/Footer.jsx
@@ -55,6 +55,9 @@ const Footer = ({ intl }) => {
                     <Link to="/download">Download Plone</Link>
                   </List.Item>
                   <List.Item>
+                    <Link to="/download/releases">Plone Releases</Link>
+                  </List.Item>
+                  <List.Item>
                     <a href="https://6.docs.plone.org">Documentation</a>
                   </List.Item>
                   <List.Item>


### PR DESCRIPTION
It is not easy to find the releases page in `plone.org`, so adding it to the footer can help.