### PR TITLE
Add link to join the Plone newsletter in the footer

### DIFF
--- a/frontend/src/customizations/volto/components/theme/Footer/Footer.jsx
+++ b/frontend/src/customizations/volto/components/theme/Footer/Footer.jsx
@@ -99,6 +99,9 @@ const Footer = ({ intl }) => {
                   <List.Item>
                     <a href="https://ploneconf.org">Conference</a>
                   </List.Item>
+                  <List.Item>
+                    <a href="https://plone.org/news-and-events/join-the-plone-newsletter">Join the Plone newsletter</a>
+                  </List.Item>
                 </List.Content>
               </List>
             </Grid.Column>


### PR DESCRIPTION
Title: Add link to join the newsletter in the footer

Description: This pull request adds a new link to join the newsletter in the footer of the website. The new link is added below the existing "Join the Plone newsletter" link.

Changes:
Modified Footer.jsx to include the new link.

Testing:
Verified that the new link appears in the footer and navigates to the correct URL.