### PR TITLE
Add link to event sponsorship page in footer navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.21 (unreleased)
 
-
+- Add "Apply for Event and Sprint Funds" link to footer navigation for easier access to /foundation/event-sponsorship page. Fixes #215. [GitHub Copilot]
 - Update to Relstorage 4.2.1
 - Simplify and make mxdev config explicit
 - Add collective.casestudy to mxdev, pin 1.0.0b1 for testing/production.

--- a/frontend/src/customizations/volto/components/theme/Footer/Footer.jsx
+++ b/frontend/src/customizations/volto/components/theme/Footer/Footer.jsx
@@ -128,6 +128,11 @@ const Footer = ({ intl }) => {
                     <Link to="/foundation/sponsorship">Sponsors</Link>
                   </List.Item>
                   <List.Item>
+                    <Link to="/foundation/event-sponsorship">
+                      Apply for Event and Sprint Funds
+                    </Link>
+                  </List.Item>
+                  <List.Item>
                     <Link to="/foundation/materials/foundation-resolutions/code-of-conduct">
                       Code of conduct
                     </Link>


### PR DESCRIPTION
Fixes #215

## Changes

This PR adds a link to the event sponsorship page (`/foundation/event-sponsorship`) in the footer navigation under the Foundation section, making it easier for users to find and apply for Plone Foundation event and sprint funds.

### What was changed:
- Added "Apply for Event and Sprint Funds" link to the Foundation section in the footer
- Positioned the link after "Sponsors" since they're related topics
- Updated CHANGELOG.md with the fix

### Why:
Previously, users had difficulty finding the event sponsorship page as there was no direct navigation link from the main foundation page. This improvement makes the page more discoverable and accessible.

### Testing:
The link has been added to `frontend/src/customizations/volto/components/theme/Footer/Footer.jsx` and will appear in the footer on all pages of the site.