### PR TITLE
Fix: Hyperlink URL in site footer trademark text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.21 (unreleased)
 
-
+- Hyperlink URL in site footer trademark text. Fixes #191 [stevepiercy]
 - Update to Relstorage 4.2.1
 - Simplify and make mxdev config explicit
 - Add collective.casestudy to mxdev, pin 1.0.0b1 for testing/production.

--- a/frontend/src/components/layout/Footer/SiteFooter.jsx
+++ b/frontend/src/components/layout/Footer/SiteFooter.jsx
@@ -49,7 +49,7 @@ const messages = defineMessages({
   footerInfos: {
     id: 'Footer infos',
     defaultMessage:
-      'The text and illustrations in this website are licensed by the Plone Foundation under a Creative Commons Attribution-ShareAlike 4.0 International license. Plone and the Plone® logo are registered trademarks of the Plone Foundation, registered in the United States and other countries. For guidelines on the permitted uses of the Plone trademarks, see https://plone.org/foundation/logo. All other trademarks are owned by their respective owners.',
+      'The text and illustrations in this website are licensed by the Plone Foundation under a Creative Commons Attribution-ShareAlike 4.0 International license. Plone and the Plone® logo are registered trademarks of the Plone Foundation, registered in the United States and other countries. For guidelines on the permitted uses of the Plone trademarks, see <a href="https://plone.org/foundation/logo">https://plone.org/foundation/logo</a>. All other trademarks are owned by their respective owners.',
   },
 });
 
@@ -163,9 +163,12 @@ const Footer = ({ pathanme }) => {
             <div className="logo">
               <Logo />
             </div>
-            <div className="address">
-              {intl.formatMessage(messages.footerInfos)}
-            </div>
+            <div
+              className="address"
+              dangerouslySetInnerHTML={{
+                __html: intl.formatMessage(messages.footerInfos),
+              }}
+            />
           </div>
         </Container>
       </div>

--- a/frontend/src/customizations/volto/components/theme/Footer/Footer.jsx
+++ b/frontend/src/customizations/volto/components/theme/Footer/Footer.jsx
@@ -20,7 +20,7 @@ const messages = defineMessages({
   footerInfos: {
     id: 'Footer infos',
     defaultMessage:
-      'The text and illustrations in this website are licensed by the Plone Foundation under a Creative Commons Attribution-ShareAlike 4.0 International license. Plone and the Plone® logo are registered trademarks of the Plone Foundation, registered in the United States and other countries. For guidelines on the permitted uses of the Plone trademarks, see https://plone.org/foundation/logo. All other trademarks are owned by their respective owners.',
+      'The text and illustrations in this website are licensed by the Plone Foundation under a Creative Commons Attribution-ShareAlike 4.0 International license. Plone and the Plone® logo are registered trademarks of the Plone Foundation, registered in the United States and other countries. For guidelines on the permitted uses of the Plone trademarks, see <a href="https://plone.org/foundation/logo">https://plone.org/foundation/logo</a>. All other trademarks are owned by their respective owners.',
   },
   cookieSettings: {
     id: 'Cookie settings',
@@ -219,9 +219,12 @@ const Footer = ({ intl }) => {
             <div className="logo">
               <Logo />
             </div>
-            <div className="address">
-              {intl.formatMessage(messages.footerInfos)}
-            </div>
+            <div
+              className="address"
+              dangerouslySetInnerHTML={{
+                __html: intl.formatMessage(messages.footerInfos),
+              }}
+            />
           </div>
         </Container>
       </div>


### PR DESCRIPTION
Fixes #191

Changes:
- Converted plain text URL to a clickable hyperlink in the footer trademark notice
- Updated both Footer.jsx files to use dangerouslySetInnerHTML to properly render the HTML link
- Added changelog entry

The URL https://plone.org/foundation/logo in the footer text is now properly hyperlinked instead of displaying as plain text.