### PR TITLE
Fix event info block: Move Website to separate section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.21 (unreleased)
 
 
+- Fix event info block: Move Website URL to separate section with its own heading. [#175]
 - Update to Relstorage 4.2.1
 - Simplify and make mxdev config explicit
 - Add collective.casestudy to mxdev, pin 1.0.0b1 for testing/production.

--- a/frontend/src/components/Blocks/InfoBox/Body.jsx
+++ b/frontend/src/components/Blocks/InfoBox/Body.jsx
@@ -68,10 +68,8 @@ const Body = (props) => {
         </>
       )}
 
-      {/* Contatcss */}
-      {(properties.contact_name ||
-        properties.event_url ||
-        properties.contact_phone) && (
+      {/* Contacts */}
+      {(properties.contact_name || properties.contact_phone) && (
         <div className="info-box-contacts">
           <h4>{intl.formatMessage(messages.contact)}</h4>
 
@@ -97,18 +95,23 @@ const Body = (props) => {
               {}
             </p>
           )}
-          {properties.event_url && (
-            <p>
-              <a
-                href={properties.event_url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {intl.formatMessage(messages.website)}
-              </a>
-            </p>
-          )}
         </div>
+      )}
+
+      {/* Website */}
+      {properties.event_url && (
+        <>
+          <h4>{intl.formatMessage(messages.website)}</h4>
+          <p>
+            <a
+              href={properties.event_url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {properties.event_url}
+            </a>
+          </p>
+        </>
       )}
 
       {/* Attendees */}


### PR DESCRIPTION
## Description

This PR fixes issue #175 where the Event URL was incorrectly displayed under the 'Contacts' heading in the event info block.

## Changes

- Separated the event URL (Website) from the Contacts section
- Added a dedicated 'Website' heading for the event URL
- Display the actual URL as the link text instead of the word 'Website'
- The Contacts section now only shows contact name/email and phone number

## Before
The Website was listed under 'Contacts' heading with the word 'Website' as the link text.

## After
The Website now has its own 'Website' heading with the actual URL displayed as a clickable link.

Fixes #175