### PR TITLE
Update funding manifest URL

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,1 +1,1 @@
-https://plone.org/funding.json
+https://github.com/plone/plone.org/

--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,1 +1,1 @@
-https://github.com/plone/plone.org/
+https://github.com/plone/

--- a/funding.json
+++ b/funding.json
@@ -10,7 +10,7 @@
     "description": "The Foundation is a 501(c)(3) non-profit organization that exists to protect and promote Plone. We provide support for development and marketing, and are modelled after similar ventures, such as the Apache Software Foundation. We are the legal owner of the Plone code base, trademarks, and domain names. Our goal is to ensure Plone remains the premier open-source content management system to broaden its acceptance and visibility. The Foundation is governed by an elected Board of Directors and supported by Members, Sponsors, Plone Teams, and the global community.",
     "webpageUrl": {
       "url": "https://plone.org/foundation/about",
-      "wellKnown": "https://plone.org/.well-known/funding-manifest-urls"
+      "wellKnown": ""
     }
   },
   "projects": [
@@ -24,7 +24,7 @@
       },
       "repositoryUrl": {
         "url": "https://github.com/plone",
-        "wellKnown": "https://github.com/plone/plone.org/.well-known/funding-manifest-urls"
+        "wellKnown": "https://plone.org/.well-known/funding-manifest-urls"
       },
       "licenses": ["spdx:GPL-2.0-only", "spdx:MIT", "spdx:ZPL-2.1", "spdx:CC-BY-4.0"],
       "tags": ["api", "development", "documentation", "information-management", "programming", "publishing", "software-engineering", "user-experience", "web-design", "web-development"]


### PR DESCRIPTION
Addresses wellKnown URL issue in #222, but needs to be deployed, then submitted to https://dir.floss.fund/submit as well.

No change log needed as this is a follow up to #222 with closing criteria now explicitly defined at https://github.com/plone/plone.org/issues/222#issuecomment-3769973109.