### PR TITLE
fix: manually copy the contents of the .well-known directory to the d…

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
 
 USER node
 COPY --from=builder /build/ /app/
+COPY --chown=node public/.well-known /app/build/public/.well-known/
 
 WORKDIR /app
 EXPOSE 3000


### PR DESCRIPTION
…estination docker image

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #227 Ref #222

As messing with `razzle.extend.js` seems complicated, and as when running in development the `.well-known` URLs work perfectly, I thought that we can copy the contents of the `.well-known` folder directly to the docker image.

I tested it locally and it works.



