### PR TITLE
feat: show ical/ICS download link in the event infobox

### DIFF
--- a/frontend/src/components/Blocks/InfoBox/Body.jsx
+++ b/frontend/src/components/Blocks/InfoBox/Body.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { When, Recurrence } from '@package/components';
 import { List } from 'semantic-ui-react';
+import Icon from '@plone/volto/components/theme/Icon/Icon';
+import calendarSVG from '@plone/volto/icons/calendar.svg';
+import { expandToBackendURL } from '@plone/volto/helpers/Url/Url';
 
 const messages = defineMessages({
   date: {
@@ -31,6 +34,10 @@ const messages = defineMessages({
   attendees: {
     id: 'attendees',
     defaultMessage: 'Attendees',
+  },
+  downloadEvent: {
+    id: 'Download Event',
+    defaultMessage: 'Download Event',
   },
 });
 
@@ -121,6 +128,23 @@ const Body = (props) => {
           <List items={properties.attendees} />
         </>
       )}
+
+      {/* ICS link */}
+      <div className="download-event">
+        <Icon name={calendarSVG} />
+        <a
+          className="ics-download"
+          target="_blank"
+          rel="noreferrer"
+          href={
+            properties && properties['@id']
+              ? `${expandToBackendURL(properties['@id'])}/ics_view `
+              : ''
+          }
+        >
+          {intl.formatMessage(messages.downloadEvent)}
+        </a>
+      </div>
     </>
   ) : (
     <></>

--- a/frontend/theme/extras/site/components/blocks/infobox.less
+++ b/frontend/theme/extras/site/components/blocks/infobox.less
@@ -28,4 +28,12 @@
       margin-bottom: 0.3rem;
     }
   }
+
+  .download-event {
+    display: flex;
+
+    a {
+      padding-top: 0.5rem;
+    }
+  }
 }


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #226 

Following code from [volto-light-theme](https://github.com/kitconcept/volto-light-theme/blob/main/frontend/packages/volto-light-theme/src/components/Blocks/EventMetadata/View.jsx#L113-L131) I bring here the link to the ICS/ical download of an event.


<img width="360" height="393" alt="2026-01-24 17-42-22" src="https://github.com/user-attachments/assets/533380e4-93cc-4da4-b7fd-cc57fc3db7e0" />

