### PR TITLE
fix: do not copy empty .well-known directory

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
 
 USER node
 COPY --from=builder /build/ /app/
-COPY --chown=node public/.well-known /app/build/public/.well-known/
+# COPY --chown=node public/.well-known /app/build/public/.well-known/
 
 WORKDIR /app
 EXPOSE 3000


### PR DESCRIPTION
I need to merge this, because after removing the `.well-known` directory the image building fails @stevepiercy 