### PR TITLE
Modification to have sponsor pages on plone.org

### DIFF
--- a/backend/src/ploneorg/src/ploneorg/profiles.zcml
+++ b/backend/src/ploneorg/src/ploneorg/profiles.zcml
@@ -4,6 +4,12 @@
     i18n_domain="ploneorg"
     >
 
+  <!-- Hide Uninstall Profile-->
+  <utility
+      factory=".setuphandlers.HiddenProfiles"
+      name="ploneorg"
+      />
+
   <genericsetup:registerProfile
       name="default"
       title="Plone.org Site: Install"

--- a/backend/src/ploneorg/src/ploneorg/profiles/default/metadata.xml
+++ b/backend/src/ploneorg/src/ploneorg/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>20230915001</version>
+  <version>20262028001</version>
   <dependencies>
     <dependency>profile-plone.volto:default</dependency>
     <dependency>profile-plone.app.vulnerabilities:default</dependency>

--- a/backend/src/ploneorg/src/ploneorg/profiles/default/metadata.xml
+++ b/backend/src/ploneorg/src/ploneorg/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>20262028001</version>
+  <version>20260208001</version>
   <dependencies>
     <dependency>profile-plone.volto:default</dependency>
     <dependency>profile-plone.app.vulnerabilities:default</dependency>

--- a/backend/src/ploneorg/src/ploneorg/profiles/default/types/FoundationSponsor.xml
+++ b/backend/src/ploneorg/src/ploneorg/profiles/default/types/FoundationSponsor.xml
@@ -31,6 +31,7 @@
     <element value="plone.publication" />
     <element value="plone.leadimage" />
     <element value="plone.categorization" />
+    <element value="volto.blocks" />
   </property>
   <property name="schema">ploneorg.content.foundationsponsor.IFoundationSponsor</property>
   <property name="model_source" />

--- a/backend/src/ploneorg/src/ploneorg/setuphandlers/__init__.py
+++ b/backend/src/ploneorg/src/ploneorg/setuphandlers/__init__.py
@@ -14,6 +14,10 @@ class HiddenProfiles(object):
             "ploneorg:uninstall",
         ]
 
+    def getNonInstallableProducts(self):
+        """Hide the upgrades package from site-creation and quickinstaller."""
+        return ["ploneorg.upgrades"]
+
 
 def populate_portal(context):
     """Post install script"""

--- a/backend/src/ploneorg/src/ploneorg/upgrades/20260208001/types.xml
+++ b/backend/src/ploneorg/src/ploneorg/upgrades/20260208001/types.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object meta_type="Plone Types Tool"
+        name="portal_types"
+>
+  <object meta_type="Dexterity FTI"
+          name="FoundationSponsor"
+  />
+</object>

--- a/backend/src/ploneorg/src/ploneorg/upgrades/20260208001/types/FoundationSponsor.xml
+++ b/backend/src/ploneorg/src/ploneorg/upgrades/20260208001/types/FoundationSponsor.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="FoundationSponsor"
+        i18n:domain="plone"
+>
+  <property name="behaviors" purge="false">
+    <element value="volto.blocks" />
+  </property>
+
+</object>

--- a/backend/src/ploneorg/src/ploneorg/upgrades/20260208001/types/FoundationSponsor.xml
+++ b/backend/src/ploneorg/src/ploneorg/upgrades/20260208001/types/FoundationSponsor.xml
@@ -4,7 +4,9 @@
         name="FoundationSponsor"
         i18n:domain="plone"
 >
-  <property name="behaviors" purge="false">
+  <property name="behaviors"
+            purge="false"
+  >
     <element value="volto.blocks" />
   </property>
 

--- a/backend/src/ploneorg/src/ploneorg/upgrades/configure.zcml
+++ b/backend/src/ploneorg/src/ploneorg/upgrades/configure.zcml
@@ -182,4 +182,34 @@
         import_steps="contentrules"
         />
   </genericsetup:upgradeSteps>
+
+  <genericsetup:registerProfile
+      name="20260208001"
+      title="Add volto.blocks behavior to FoundationSponsors"
+      description="Configuration for version 20260208001"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      directory="20260208001"
+      />
+
+  <genericsetup:upgradeSteps
+      profile="ploneorg:default"
+      source="20230915001"
+      destination="20260208001"
+      >
+
+    <upgradeStep
+        title="Add volto.blocks behavior to FoundationSponsors"
+        description="Add new behavior"
+        handler=".v20260208001.upgrade"
+        />
+
+    <genericsetup:upgradeDepends
+        title="Add volto.blocks behavior to FoundationSponsors (GS profile)"
+        description="Add new behavior"
+        import_profile="ploneorg.upgrades:20260208001"
+        />
+
+  </genericsetup:upgradeSteps>
+
 </configure>

--- a/backend/src/ploneorg/src/ploneorg/upgrades/v20260208001.py
+++ b/backend/src/ploneorg/src/ploneorg/upgrades/v20260208001.py
@@ -1,0 +1,6 @@
+from ploneorg import logger
+
+
+def upgrade(setup_tool=None):
+    """"""
+    logger.info("Running upgrade (Python): Add behavior to FoundationSponsor")

--- a/backend/src/ploneorg/tests/test_setup.py
+++ b/backend/src/ploneorg/tests/test_setup.py
@@ -1,4 +1,5 @@
 """Setup tests for this package."""
+
 from kitconcept import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -34,7 +35,7 @@ class TestSetup(unittest.TestCase):
         """Test latest version of default profile."""
         self.assertEqual(
             self.setup.getLastVersionForProfile("ploneorg:default")[0],
-            "20230915001",
+            "20260208001",
         )
 
 

--- a/backend/src/ploneorg/tests/test_upgrades.py
+++ b/backend/src/ploneorg/tests/test_upgrades.py
@@ -1,4 +1,5 @@
 """Upgrades tests for this package."""
+
 from parameterized import parameterized
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -42,7 +43,7 @@ class UpgradeStepIntegrationTest(unittest.TestCase):
             ("20230530001", "20230904001", 1),
             ("20230904001", "20230907001", 1),
             ("20230907001", "20230915001", 1),
-
+            ("20230915001", "20260208001", 1),
         ]
     )
     def test_available(self, src, dst, expected):

--- a/frontend/src/components/Blocks/Listing/variations/SponsorCardListing.jsx
+++ b/frontend/src/components/Blocks/Listing/variations/SponsorCardListing.jsx
@@ -9,7 +9,7 @@ import {
 } from '@package/components';
 
 const SponsorCardListing = (props) => {
-  const { items, isEditMode, cols = 3 } = props;
+  const { items, isEditMode, cols = 3, linkToPage = false } = props;
 
   const randomized_items = items
     .map((value) => ({ value, sort: Math.random() }))
@@ -28,6 +28,7 @@ const SponsorCardListing = (props) => {
                   key={item['@id']}
                   {...item}
                   isEditMode={isEditMode}
+                  linkToPage={linkToPage}
                 ></SponsorCard>
               </Grid.Column>
             );

--- a/frontend/src/components/cards/SponsorCard.jsx
+++ b/frontend/src/components/cards/SponsorCard.jsx
@@ -15,7 +15,11 @@ const SponsorCard = (props) => {
 
   return (
     <Card className={cardClass}>
-      <UniversalLink item={props}>{image}</UniversalLink>
+      {props.linkToPage ? (
+        <UniversalLink href={props['@id']}>{image}</UniversalLink>
+      ) : (
+        <UniversalLink item={props}>{image}</UniversalLink>
+      )}
     </Card>
   );
 };

--- a/frontend/src/config/Blocks/schemas/listing-variations/sponsor-card-variation-schema.js
+++ b/frontend/src/config/Blocks/schemas/listing-variations/sponsor-card-variation-schema.js
@@ -7,6 +7,16 @@ const messages = defineMessages({
     id: 'Number of columns',
     defaultMessage: 'Number of columns',
   },
+  linkToPage: {
+    id: 'Link to page?',
+    defaultMessage: 'Link to page?',
+  },
+  linkToPageDescription: {
+    id:
+      'If selected, each card will always link to the page on the site instead of the remote url',
+    defaultMessage:
+      'If selected, each card will always link to the page on the site instead of the remote url',
+  },
 });
 
 const getSponsorCardVariationSchema = (
@@ -25,6 +35,18 @@ const getSponsorCardVariationSchema = (
     pos,
     'default',
   );
+
+  pos++;
+  addSchemaField(
+    schema,
+    'linkToPage',
+    intl.formatMessage(messages.linkToPage),
+    intl.formatMessage(messages.linkToPageDescription),
+    { type: 'boolean', default: false },
+    pos,
+    'default',
+  );
+
   pos++;
 
   pos = addPresetFields(schema, intl, pos, 'items', {


### PR DESCRIPTION
Fixes: #241

Added features:

- Add volto.blocks support to Foundation Sponsors
- Enhance the schema of the Foundation Sponsor Listing to be able to select whether we want to link to each sponsor's page or to their website.