### PR TITLE
Set tweaked why-plone/faq long grid columns margin-bottom and lineheight

### DIFF
--- a/frontend/theme/extras/main.less
+++ b/frontend/theme/extras/main.less
@@ -145,3 +145,32 @@ table.slate-table td p {
 table.slate-table th p {
   font-size: 0.9em;
 }
+
+// Set why-plone/faq long grid columns margin-bottom and lineheight styles
+
+body.section-why-plone.section-faq {
+  h2 {
+    margin: 0 !important;
+    line-height: 1.1em;
+    margin-bottom: 1.7em !important;
+  }
+  h3 {
+    line-height: 1.2em;
+    margin: 0 !important;
+    margin-top: 1.2em !important;
+    margin-bottom: 0.7em !important;
+  }
+
+  block.__grid h2:not(.headline), 
+  .block.__grid h3:not(.headline), 
+  [class$=Grid] .block h2:not(.headline), 
+  [class$=Grid] .block h3:not(.headline) {
+    margin: unset;
+    margin-top: 1em !important;
+    margin-bottom: 0.7em !important;
+  }
+
+  .ui.grid>.row>.stretched.column>*, .ui.grid>.stretched.column:not(.row)>*, .ui.grid>.stretched.row>.column>*, .ui.stretched.grid>.column>*, .ui.stretched.grid>.row>.column>* {
+    flex-grow: unset;
+  }
+}


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

### Purpose / Origin
The margin bottom and block spacing of the headlines in the grid columns of https://plone.org/why-plone/faq needed another iteration to fix the unpleasant CSS. 

Reason: The content of the blocks is stretched between paragraphs, which leads to too big gaps, when the amount of content in the columns differs significantly.

### Outlook
This change is limited to this section! To make it generally available you need more testing if other content is affected. This is because people had to add manually `<br>` to make the stuff look good.

### TODO 
After changing the CSS, manually added `<br>` need to be removed.
- go to https://plone.org/why-plone/faq as editor
- remove all obsolete `<br>` line feeds in the three grid columns
- should look good then like this: 

<img width="1339" height="1194" alt="image" src="https://github.com/user-attachments/assets/eebce193-4885-4c26-a504-0fc07f42229c" />


