### PR TITLE
feat: plantinum sponsor logo changes

### DIFF
--- a/frontend/src/components/Blocks/Listing/variations/SponsorCardListing.jsx
+++ b/frontend/src/components/Blocks/Listing/variations/SponsorCardListing.jsx
@@ -9,12 +9,20 @@ import {
 } from '@package/components';
 
 const SponsorCardListing = (props) => {
-  const { items, isEditMode, cols = 3, linkToPage = false } = props;
+  const {
+    items,
+    isEditMode,
+    cols = 3,
+    linkToPage = false,
+    randomize = true,
+  } = props;
 
-  const randomized_items = items
-    .map((value) => ({ value, sort: Math.random() }))
-    .sort((a, b) => a.sort - b.sort)
-    .map(({ value }) => value);
+  const randomized_items = randomize
+    ? items
+        .map((value) => ({ value, sort: Math.random() }))
+        .sort((a, b) => a.sort - b.sort)
+        .map(({ value }) => value)
+    : items;
 
   return (
     <PresetWrapper {...props} className="simple-card-listing">

--- a/frontend/src/components/FooterSponsors/FooterSponsors.jsx
+++ b/frontend/src/components/FooterSponsors/FooterSponsors.jsx
@@ -6,7 +6,7 @@ import { Button } from '@package/components';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { UniversalLink } from '@plone/volto/components';
 
-import yourLogoHereSVG from './YourLogo.svg';
+import yourLogoHereSVG from './YourLogov2.svg';
 
 const FooterSponsors = (props) => {
   const { type = 'platinum' } = props;
@@ -41,7 +41,7 @@ const FooterSponsors = (props) => {
       })
     : [];
 
-  const listingSize = 5;
+  const listingSize = sponsorItems.length + 1;
 
   if (sponsorItems.length > 0) {
     const remainder = sponsorItems.length % listingSize;

--- a/frontend/src/components/FooterSponsors/FooterSponsors.jsx
+++ b/frontend/src/components/FooterSponsors/FooterSponsors.jsx
@@ -6,6 +6,8 @@ import { Button } from '@package/components';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { UniversalLink } from '@plone/volto/components';
 
+import yourLogoHereSVG from './YourLogo.svg';
+
 const FooterSponsors = (props) => {
   const { type = 'platinum' } = props;
   const subrequest_key = `${type}_sponsors`;
@@ -31,13 +33,41 @@ const FooterSponsors = (props) => {
     );
   }, [dispatch, subrequest_key, type]);
 
-  const plural = sponsors?.items.length > 1 ? 's' : '';
+  const plural = sponsors?.items.length > 1 ? 's' : '(s)';
   const capitalizedType = String(type[0]).toUpperCase() + String(type).slice(1);
+  const sponsorItems = sponsors?.loaded
+    ? sponsors.items.length > 0 &&
+      sponsors.items.map((item) => {
+        item['size'] = 'thumb';
+        return item;
+      })
+    : [];
+
+  const listingSize = 5;
+
+  if (sponsorItems.length > 0) {
+    const remainder = sponsorItems.length % listingSize;
+    if (remainder > 0) {
+      const placeholdersToAdd = listingSize - remainder;
+      for (let i = 0; i < placeholdersToAdd; i++) {
+        sponsorItems.push({
+          '@id': '/foundation/sponsorship',
+          title: 'Put your logo here',
+          size: 'thumb',
+          isPlaceholder: true,
+          image: {
+            scales: { thumb: { download: yourLogoHereSVG } },
+          },
+        });
+      }
+    }
+  }
+
   return sponsors?.loaded
     ? sponsors.items.length > 0 && (
         <div className={`footer-sponsors-listing ${subrequest_key}`}>
           <div className="footer-sponsors-listing-headline">
-            <h3>{`Our proud ${capitalizedType} Sponsor${plural}`}</h3>
+            <h3>Powering the Future of Open Sovereignty</h3>
             <Button
               as={UniversalLink}
               primary
@@ -45,10 +75,22 @@ const FooterSponsors = (props) => {
               href={flattenToAppURL('/foundation/sponsorship')}
               arrow={true}
             >
-              Become a Sponsor
+              Become a sponsor — every contribution shapes our future!
             </Button>
           </div>
-          <SponsorCardListing items={sponsors.items || []} />
+          <p>
+            Plone thrives because of organizations that believe in secure,
+            independent, and open technology. We are deeply grateful to our
+            Platinum Sponsors for their visionary support in sustaining the
+            world's most secure CMS. Join them in shaping the future of digital
+            freedom.
+          </p>
+
+          <SponsorCardListing
+            items={sponsorItems || []}
+            cols={listingSize}
+            randomize={false}
+          />
         </div>
       )
     : '';

--- a/frontend/src/components/FooterSponsors/FooterSponsors.jsx
+++ b/frontend/src/components/FooterSponsors/FooterSponsors.jsx
@@ -33,8 +33,6 @@ const FooterSponsors = (props) => {
     );
   }, [dispatch, subrequest_key, type]);
 
-  const plural = sponsors?.items.length > 1 ? 's' : '(s)';
-  const capitalizedType = String(type[0]).toUpperCase() + String(type).slice(1);
   const sponsorItems = sponsors?.loaded
     ? sponsors.items.length > 0 &&
       sponsors.items.map((item) => {

--- a/frontend/src/components/FooterSponsors/YourLogo.svg
+++ b/frontend/src/components/FooterSponsors/YourLogo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="100" viewBox="0 0 300 100">
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="central" font-family="Arial, sans-serif" font-size="24" fill="#0086c3">YOUR LOGO HERE</text>
+</svg>

--- a/frontend/src/components/FooterSponsors/YourLogov2.svg
+++ b/frontend/src/components/FooterSponsors/YourLogov2.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="300"
+   height="100"
+   viewBox="0 0 300 100"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <text
+     x="50%"
+     y="50%"
+     text-anchor="middle"
+     dominant-baseline="central"
+     font-family="Arial, sans-serif"
+     font-size="24"
+     fill="#0086c3"
+     id="text1">YOUR LOGO HERE</text>
+  <rect
+     style="fill:none;stroke:#000000;stroke-opacity:1;stroke-dasharray:1,6;stroke-dashoffset:0"
+     id="rect1"
+     width="259.11655"
+     height="56.672935"
+     x="22.274437"
+     y="20.582706" />
+</svg>

--- a/frontend/src/components/cards/SponsorCard.jsx
+++ b/frontend/src/components/cards/SponsorCard.jsx
@@ -6,7 +6,11 @@ import { UniversalLink } from '@plone/volto/components';
 import { ListingImage } from '@package/components';
 
 const SponsorCard = (props) => {
-  let image = ListingImage({ item: props, className: 'item-image' });
+  let image = ListingImage({
+    item: props,
+    className: 'item-image',
+    size: props?.size,
+  });
 
   let cardClass = cx('item', {
     'sponsor-card': true,

--- a/frontend/theme/extras/custom.overrides
+++ b/frontend/theme/extras/custom.overrides
@@ -59,6 +59,5 @@
 @import 'site/components/widgets/image_widget.less';
 
 @import 'site/components/controlpanels/membership.less';
-@import 'site/components/footer_sponsors.less';
 
 @import 'site/print.less';

--- a/frontend/theme/extras/site/components/footer_sponsors.less
+++ b/frontend/theme/extras/site/components/footer_sponsors.less
@@ -1,6 +1,0 @@
-.footer-sponsors-listing-headline {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-}

--- a/frontend/theme/extras/site/components/layout/footer.less
+++ b/frontend/theme/extras/site/components/layout/footer.less
@@ -1,9 +1,9 @@
 #footer {
   padding: 2rem 0 0 0;
   margin: 1rem 0 0 0;
+  background-color: @footerLightGrey;
   box-shadow: 0px 5px 7px 5px rgba(119, 119, 119, 0.1);
   font-family: @headerFontName;
-  background-color: @footerLightGrey;
 
   #footer-main {
     display: flex;

--- a/frontend/theme/extras/site/components/layout/footer.less
+++ b/frontend/theme/extras/site/components/layout/footer.less
@@ -3,6 +3,7 @@
   margin: 1rem 0 0 0;
   box-shadow: 0px 5px 7px 5px rgba(119, 119, 119, 0.1);
   font-family: @headerFontName;
+  background-color: @footerLightGrey;
 
   #footer-main {
     display: flex;
@@ -63,6 +64,21 @@
           }
         }
       }
+    }
+  }
+
+  .footer-sponsors-listing {
+    padding-bottom: 2em;
+
+    .footer-sponsors-listing-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .item {
+      background-color: transparent;
     }
   }
 

--- a/frontend/theme/globals/site.variables
+++ b/frontend/theme/globals/site.variables
@@ -118,6 +118,9 @@
 /*--- --------------------------------Plone.org Variables-------------------------------- ---*/
 /*--- -------------------------------------------------------------------------------- ---*/
 
+@footerLightGrey: #f7f7f7;
+
+
 @footerBordersColor: @lightGrey;
 @footerColumnsTextColor: #222;
 @footerLastColumnTextColor: #737373;


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

These are the changes:

- Smaller logo (`thumb` scale)
- Change headline and add text before the platinum logos
- Add an empty logo to call future sponsors

This should be the appearance. It requires the platinum sponsor logo to have a transparent background (which my demo logos have not)

<img width="1910" height="723" alt="2026-03-05 21-31-20" src="https://github.com/user-attachments/assets/bb1582f7-c911-4718-91b1-7d81e87ca01e" />
